### PR TITLE
Issue #44 fixed

### DIFF
--- a/lib/flutter_sms_web.dart
+++ b/lib/flutter_sms_web.dart
@@ -7,7 +7,7 @@ import 'src/flutter_sms_platform.dart';
 
 class FlutterSmsPlugin extends FlutterSmsPlatform {
   static void registerWith(Registrar registrar) {
-    WidgetsFlutterBinding.ensureInitialized();
+    // WidgetsFlutterBinding.ensureInitialized();
     FlutterSmsPlatform.instance = FlutterSmsPlugin();
   }
 


### PR DESCRIPTION
On web, because `generated_plugin_registrant.dart` file is auto loaded, it will run before the actual app runs. I'm not sure why `WidgetsFlutterBinding.ensureInitialized()` cause this problem but it seems removing it, fixes the issue.