### PR TITLE
Add note about android intent to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ You can send multiple ways:
 This will populate the correct fields.
 
 
+## Setup
+
+### Android
+
+For Android API level > 30 you will need to add the following query to your AndroidManifest.xml
+
+```
+<queries>
+    <intent>
+        <action android:name="android.intent.action.SENDTO" />
+        <data android:scheme="smsto" />
+    </intent>
+</queries>
+```
+
+Without this, some Android devices may incorrectly return false for `canSend()`.
+
 ## Example
 
 Make sure to Install and Import the Package.


### PR DESCRIPTION
Some devices using newer versions of android were returning `false` for `canSend` even though they definitely could send SMS. Further, because `sendSMS` calls `canSend` internally, it effectively meant the plugin did not work.

Adding this intent to the AndroidManifest.xml for the app meant that `canSend` returned `true` as expected.