### PR TITLE
Use enum result rather than string

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ Create a function for sending messages.
 
 ``` dart
 void _sendSMS(String message, List<String> recipents) async {
- String _result = await sendSMS(message: message, recipients: recipents)
-        .catchError((onError) {
-      print(onError);
-    });
-print(_result);
+  SendSMSResult result = await sendSMS(
+    message: message,
+    recipients: recipents,
+  ).catchError((onError) => print(onError));
+
+  print(result);
 }
 ```
 
@@ -69,11 +70,13 @@ On Android, you can skip the additional dialog with the sendDirect parameter.
 String message = "This is a test message!";
 List<String> recipents = ["1234567890", "5556787676"];
 
- String _result = await sendSMS(message: message, recipients: recipents, sendDirect: true)
-        .catchError((onError) {
-      print(onError);
-    });
-print(_result);
+SendSMSResult result = await sendSMS(
+  message: message,
+  recipients: recipents,
+  sendDirect: true,
+).catchError((onError) => print(onError));
+
+print(result);
 ```
 
 NOTE: This also requires the SEND_SMS permission to be added to the AndroidManifest.xml

--- a/android/src/main/kotlin/com/example/flutter_sms/FlutterSmsPlugin.kt
+++ b/android/src/main/kotlin/com/example/flutter_sms/FlutterSmsPlugin.kt
@@ -125,7 +125,7 @@ class FlutterSmsPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
       }
     }
 
-    result.success("SMS Sent!")
+    result.success("sent")
   }
 
   private fun sendSMSDialog(result: Result, phones: String, message: String) {
@@ -134,6 +134,6 @@ class FlutterSmsPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     intent.putExtra("sms_body", message)
     intent.putExtra(Intent.EXTRA_TEXT, message)
     activity?.startActivityForResult(intent, REQUEST_CODE_SEND_SMS)
-    result.success("SMS Sent!")
+    result.success("sent")
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -30,12 +30,27 @@ class _MyAppState extends State<MyApp> {
 
   Future<void> _sendSMS(List<String> recipients) async {
     try {
-      String _result = await sendSMS(
+      SendSMSResult _result = await sendSMS(
         message: _controllerMessage.text,
         recipients: recipients,
         sendDirect: sendDirect,
       );
-      setState(() => _message = _result);
+      setState(() {
+        switch (_result) {
+          case SendSMSResult.sent:
+            _message = 'SMS Sent!';
+            break;
+          case SendSMSResult.failed:
+            _message = 'Failed';
+            break;
+          case SendSMSResult.cancelled:
+            _message = 'Cancelled';
+            break;
+          case SendSMSResult.unknownError:
+            _message = 'Not sent';
+            break;
+        }
+      });
     } catch (error) {
       setState(() => _message = error.toString());
     }

--- a/lib/flutter_sms.dart
+++ b/lib/flutter_sms.dart
@@ -2,8 +2,10 @@ import 'dart:async';
 
 import 'src/flutter_sms_platform.dart';
 
+enum SendSMSResult { sent, failed, cancelled, unknownError }
+
 /// Open SMS Dialog on iOS/Android/Web
-Future<String> sendSMS({
+Future<SendSMSResult> sendSMS({
   required String message,
   required List<String> recipients,
   bool sendDirect = false,

--- a/lib/flutter_sms_web.dart
+++ b/lib/flutter_sms_web.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
+import 'flutter_sms.dart';
 import 'src/flutter_sms_platform.dart';
 
 class FlutterSmsPlugin extends FlutterSmsPlatform {
@@ -12,15 +12,15 @@ class FlutterSmsPlugin extends FlutterSmsPlatform {
   }
 
   @override
-  Future<String> sendSMS({
+  Future<SendSMSResult> sendSMS({
     required String message,
     required List<String> recipients,
     bool sendDirect = false,
   }) async {
     bool _messageSent =
         await FlutterSmsPlatform.instance.launchSmsMulti(recipients, message);
-    if (_messageSent) return 'Message Sent!';
-    return 'Error Sending Message!';
+    if (_messageSent) return SendSMSResult.sent;
+    return SendSMSResult.unknownError;
   }
 
   @override


### PR DESCRIPTION
Returns an enum `SendSMSResult` with the result of sending the message, rather than a string.