### PR TITLE
Update kotlin version to 1.8.22

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.example.flutter_sms'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.8.22'
     repositories {
         google()
         jcenter()

--- a/android/src/main/kotlin/com/example/flutter_sms/FlutterSmsPlugin.kt
+++ b/android/src/main/kotlin/com/example/flutter_sms/FlutterSmsPlugin.kt
@@ -18,7 +18,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 
 
 class FlutterSmsPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
@@ -61,14 +60,14 @@ class FlutterSmsPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
 
   // V1 embedding entry point. This is deprecated and will be removed in a future Flutter
   // release but we leave it here in case someone's app does not utilize the V2 embedding yet.
-  companion object {
-    @JvmStatic
-    fun registerWith(registrar: Registrar) {
-      val inst = FlutterSmsPlugin()
-      inst.activity = registrar.activity()
-      inst.setupCallbackChannels(registrar.messenger())
-    }
-  }
+  // companion object {
+  //   @JvmStatic
+  //   fun registerWith(registrar: Registrar) {
+  //     val inst = FlutterSmsPlugin()
+  //     inst.activity = registrar.activity()
+  //     inst.setupCallbackChannels(registrar.messenger())
+  //   }
+  // }
 
   override fun onMethodCall(call: MethodCall, result: Result) {
     when (call.method) {


### PR DESCRIPTION
What went wrong:
The Android Gradle plugin supports only Kotlin Gradle plugin version 1.5.20 and higher.
The following dependencies do not satisfy the required version:
project ':flutter_sms' -> org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50

so that's why we need to update it's kotlin version to latest